### PR TITLE
Allow Image and Canvas in BitmapLuminanceSource

### DIFF
--- a/BitmapLuminanceSource.js
+++ b/BitmapLuminanceSource.js
@@ -43,8 +43,8 @@ ZXing.BitmapLuminanceSource = function (bitmap, w, h) {
       data = bitmap.data;
     }*/ else {
       canvas = w;
-      width = canvas.naturalWidth;
-      height = canvas.naturalHeight;
+      width = canvas.naturalWidth || canvas.width;
+      height = canvas.naturalHeight || canvas.height;
       var imageData = bitmap.getImageData(0, 0, width, height);
       data = imageData.data;
     }


### PR DESCRIPTION
My case was:
```
        const source = new ZXing.BitmapLuminanceSource(
          canvas.getContext('2d'),
          canvas
        );
```
But it throwed an error `Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The source width is 0.` because it was looking for canvas.naturalWidth.
Canvas does not have naturalWidth property, Image does.